### PR TITLE
Build mapnik for ios, including arm64

### DIFF
--- a/osx/iPhoneSimulator64.sh
+++ b/osx/iPhoneSimulator64.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -u
+
+export PLATFORM="iPhoneSimulator"
+export HOST_PLATFORM="MacOSX"
+export BOOST_ARCH="x86"
+export ARCH_NAME="x86_64"
+export HOST_ARG="--host=i686-apple-darwin11"
+export ACTIVE_SDK_VERSION="`xcrun --sdk iphonesimulator --show-sdk-version`"
+export MIN_SDK_VERSION_FLAG="-miphoneos-version-min=${ACTIVE_SDK_VERSION}"
+if [[ "${CXX11:-false}" == false ]]; then
+  export CXX11=false
+fi
+
+source $(dirname "$BASH_SOURCE")/settings.sh

--- a/osx/patches/protobuf-ios-arm64.diff
+++ b/osx/patches/protobuf-ios-arm64.diff
@@ -1,0 +1,14 @@
+diff --git a/osx/out/packages/protobuf-2.5.0-arm64/src/google/protobuf/stubs/platform_macros.h b/osx/out/packages/protobuf-2.5.0-arm64/src/google/protobuf/stubs/platform_macros.h
+index b1df60e..afe18a0 100644
+--- a/osx/out/packages/protobuf-2.5.0-arm64/src/google/protobuf/stubs/platform_macros.h
++++ b/osx/out/packages/protobuf-2.5.0-arm64/src/google/protobuf/stubs/platform_macros.h
+@@ -57,6 +57,9 @@
+ #elif defined(__ppc__)
+ #define GOOGLE_PROTOBUF_ARCH_PPC 1
+ #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
++#elif defined(__aarch64__)
++#define GOOGLE_PROTOBUF_ARCH_ARM 1
++#define GOOGLE_PROTOBUF_ARCH_64_BIT 1
+ #else
+ #error Host architecture was not detected as supported by protobuf
+ #endif

--- a/osx/scripts/build_protobuf.sh
+++ b/osx/scripts/build_protobuf.sh
@@ -11,6 +11,10 @@ rm -rf protobuf-${PROTOBUF_VERSION}-${ARCH_NAME}
 tar xf protobuf-${PROTOBUF_VERSION}.tar.bz2
 mv protobuf-${PROTOBUF_VERSION} protobuf-${PROTOBUF_VERSION}-${ARCH_NAME}
 cd protobuf-${PROTOBUF_VERSION}-${ARCH_NAME}
+
+#Fix for arm64 https://code.google.com/p/protobuf/issues/detail?id=575
+patch src/google/protobuf/stubs/platform_macros.h < ../../../patches/protobuf-ios-arm64.diff
+
 export NATIVE_PROTOC="${PACKAGES}/protobuf-${PROTOBUF_VERSION}-x86_64/src/protoc"
 if [ $BOOST_ARCH = "arm" ]; then
     if [ ! -f "${NATIVE_PROTOC}" ]; then

--- a/osx/scripts/make_universal_ios.sh
+++ b/osx/scripts/make_universal_ios.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e -u
+set -o pipefail
+mkdir -p "${BUILD_UNIVERSAL}"
+
+if [[ $UNAME == 'Darwin' ]]; then
+    echo '*making universal libs*'
+    ARCHS="arm64 armv7s armv7 i386"
+    LIBS=$(find ${ROOTDIR}/out/*/lib -maxdepth 1 -name '*.a' -exec basename '{}' \; | sort | uniq)
+
+    for arch in ${ARCHS}; do
+        if [ -d "${BUILD_ROOT}-${arch}" ]; then
+            echo '*merging '${BUILD_ROOT}'-'${arch}'*'
+            ditto "${BUILD_ROOT}-${arch}/" "${BUILD_ROOT}-universal"
+            build_root_escaped=$(echo "${BUILD_ROOT}" | sed -e 's/[]\/()$*.^|[]/\\&/g')
+            find ${BUILD_ROOT}-universal/ \( -name "*.pc" -or -name "*.la" -or -name "*-config" \) \
+                -exec sed -i '' "s/${build_root_escaped}-${arch}/${build_root_escaped}-universal/g" {} \;
+        fi
+    done;
+
+    for libname in ${LIBS}; do
+        echo '*making universal '$libname'*'
+        FROM_LIBS=""
+        for arch in ${ARCHS}; do
+            if [ -f "${BUILD_ROOT}-${arch}/lib/${libname}" ]; then
+                FROM_LIBS="$FROM_LIBS ${BUILD_ROOT}-${arch}/lib/${libname}"
+            fi
+        done;
+
+        lipo -create -output \
+            "${BUILD_UNIVERSAL}/lib/${libname}" \
+            $FROM_LIBS
+        lipo -info "${BUILD_UNIVERSAL}/lib/${libname}"
+    done;
+
+    if [ -f ${MAPNIK_BIN_SOURCE}/lib/libmapnik.a ]; then
+        echo '*making universal mapnik*'
+        lipo -create -output \
+            "${BUILD_UNIVERSAL}/libmapnik.a" \
+            "${BUILD_ROOT}-arm64-mapnik/${MAPNIK_INSTALL}/lib/libmapnik.a" \
+            "${BUILD_ROOT}-armv7s-mapnik/${MAPNIK_INSTALL}/lib/libmapnik.a" \
+            "${BUILD_ROOT}-armv7-mapnik/${MAPNIK_INSTALL}/lib/libmapnik.a" \
+            "${BUILD_ROOT}-i386-mapnik/${MAPNIK_INSTALL}/lib/libmapnik.a"
+    fi
+
+fi
+

--- a/osx/scripts/rebuild_ios.sh
+++ b/osx/scripts/rebuild_ios.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 set -e -u
 set -o pipefail
+
+export CXX11=true
+source iPhoneOS.sh
+
 cd "$( dirname $( dirname "$0" ))"
+
+branch="2.2.x"
+if [ ! -d ${MAPNIK_SOURCE} ]; then
+  git clone --quiet https://github.com/mapnik/mapnik.git ${MAPNIK_SOURCE} -b $branch
+  git branch -v
+fi
+
 # update mapnik
-cd mapnik
+cd ${MAPNIK_SOURCE}
 echo 'pulling from git'
 #git pull
 echo
@@ -18,12 +29,21 @@ else
   echo "new build detected, carrying on"
 fi
 
-BUILD_DEPS=false
+BUILD_DEPS=true
 
 function build_all {
   if [ $BUILD_DEPS = true ];  then
-    ./scripts/build_core_deps.sh
+    ./scripts/build_freetype.sh
+    ./scripts/build_icu.sh
     ./scripts/build_protobuf.sh
+    BOOST_LIBRARIES="--with-thread --with-filesystem --disable-filesystem2 --with-system --with-regex"
+    ./scripts/build_boost.sh ${BOOST_LIBRARIES}
+    ./scripts/build_jpeg.sh
+    ./scripts/build_png.sh
+    ./scripts/build_libxml2.sh
+    ./scripts/build_pkg_config.sh
+    ./scripts/build_bzip2.sh
+    ./scripts/build_zlib.sh
   fi
   ./scripts/build_mapnik_mobile.sh
 }
@@ -44,6 +64,10 @@ build_all
 
 # armv7s
 source iPhoneOSs.sh
+build_all
+
+# armv64
+source iPhoneOS64.sh
 build_all
 
 # done now package

--- a/osx/scripts/rebuild_ios.sh
+++ b/osx/scripts/rebuild_ios.sh
@@ -48,10 +48,10 @@ function build_all {
   ./scripts/build_mapnik_mobile.sh
 }
 
-# x86_64
-source MacOSX.sh
-# required for bcp header copy
-build_all
+# # x86_64
+# source MacOSX.sh
+# # required for bcp header copy
+# build_all
 
 # i386
 source iPhoneSimulator.sh
@@ -71,6 +71,6 @@ source iPhoneOS64.sh
 build_all
 
 # done now package
-./scripts/make_universal.sh
-# TODO 
+./scripts/make_universal_ios.sh
+# TODO
 ./scripts/package_mobile_sdk.sh

--- a/osx/scripts/rebuild_ios.sh
+++ b/osx/scripts/rebuild_ios.sh
@@ -53,8 +53,13 @@ function build_all {
 # # required for bcp header copy
 # build_all
 
-# i386
+# 32-bit simulator
 source iPhoneSimulator.sh
+# required first for cross compiling later on arm
+build_all
+
+# 64-bit simulator
+source iPhoneSimulator64.sh
 # required first for cross compiling later on arm
 build_all
 
@@ -71,6 +76,6 @@ source iPhoneOS64.sh
 build_all
 
 # done now package
-./scripts/make_universal_ios.sh
+./scripts/make_universal.sh
 # TODO
-./scripts/package_mobile_sdk.sh
+#./scripts/package_mobile_sdk.sh


### PR DESCRIPTION
Updated the rebuild_ios.sh script to build a universal i386/armv7/armv7s/arm64 lib.
Run ./scripts/rebuild_ios.sh from ./osx folder

It seems to build fine (it's usable without any issues so far) but the script currently fails at the last step:
./scripts/package_mobile_sdk.sh: line 67: ./dist/bin/bcp: No such file or directory
The comment, "required for bcp header copy", in the rebuild_ios.sh script hint that building the x86_64 arch is required for the packaging to succeed, but it failed the same way regardless. I've commented out the x86 from the script since it's not needed when targeting ios.

Afterwards I needed to manually copy the mapnik includes from the source into the out-directory.
Probably as a result of the packaging step not succeeding..?
